### PR TITLE
Fix: Update RPC port and standardize chain name handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ go build or go install wallet-chain-utxo
 ### Start the RPC interface test interface
 
 ```bash
-grpcui -plaintext 127.0.0.1:8189
+grpcui -plaintext 127.0.0.1:8389
 ```
 
 ## Contribute


### PR DESCRIPTION
This PR includes two main changes:

1.  **Updated RPC Interface Port in README:** The `README.md` has been updated to reflect the correct RPC interface port, changing from `8189` to `8389`.
2.  **Standardized Chain Name Handling in Dispatcher:** The chain name handling in `chaindispatcher/dispatcher.go` has been standardized to use lowercase. This ensures consistent chain identification and prevents potential issues caused by case sensitivity. All chain names are now converted to lowercase before being used in the dispatcher logic, including in the `chainAdaptorFactoryMap`, `supportedChains` list, and when retrieving the chain name from requests in the `Interceptor` and `preHandler` functions.

This standardization improves the robustness and reliability of the chain dispatching mechanism.
